### PR TITLE
Fix README syntax for install append

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Luxonis Layer for Yocto
 To layer features to you OS image, add the following to your conf/local.conf file:
 
 ```
-IMAGE_INSTALL:append = \"
+IMAGE_INSTALL:append = " \
     depthai-core-examples \
     depthai-core-tests \
     movidius-udev-rule \


### PR DESCRIPTION
The line continuation needs to follow the opening quote.