### PR TITLE
Set libarchive to build position-independent

### DIFF
--- a/recipes-support/libarchive-luxonis/libarchive-luxonis_git.bb
+++ b/recipes-support/libarchive-luxonis/libarchive-luxonis_git.bb
@@ -29,6 +29,7 @@ S = "${WORKDIR}/git"
 inherit cmake pkgconfig
 
 EXTRA_OECMAKE += "\
+    -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
     -D BACKWARD_TESTS=OFF \
     -D ENABLE_ACL=OFF \
     -D ENABLE_BZip2=OFF \


### PR DESCRIPTION
When building on x86_64, it would fail while attempting to link to a shared object of the libarchive library. It would only find a static library available. It doesn't appear that the position-independent flag (-fPIC) was getting applied to the libarchive recipe. Add the position-independent flag to the extra cmake arguments to fix the issue.